### PR TITLE
Zmiany w funkcjonowaniu edycji profliu użytkownika

### DIFF
--- a/API ENDPOINTS.md
+++ b/API ENDPOINTS.md
@@ -38,17 +38,37 @@ Ten dokument zawiera kompleksową listę wszystkich endpointów API dostępnych 
   - Sukces: Informacje o użytkowniku (bez hasła)
   - Błąd: Komunikat o błędzie
 
-### PUT /api/user/profile/{userId}
-- **Opis**: Aktualizuje informacje o profilu użytkownika
+### PUT /api/user/profile/{userId}/username
+- **Opis**: Aktualizuje nazwę użytkownika
 - **Parametry ścieżki**:
   - `userId`: ID użytkownika do aktualizacji
 - **Treść żądania**: 
-  - `username`: Zaktualizowana nazwa użytkownika
-  - `email`: Zaktualizowany email
-  - `password`: Zaktualizowane hasło (opcjonalne)
+  - `username`: Nowa nazwa użytkownika
 - **Odpowiedź**: 
   - Sukces: Komunikat o powodzeniu
   - Błąd: Komunikat o błędzie
+
+### PUT /api/user/profile/{userId}/email
+- **Opis**: Aktualizuje email użytkownika
+- **Parametry ścieżki**:
+  - `userId`: ID użytkownika do aktualizacji
+- **Treść żądania**: 
+  - `email`: Nowy email użytkownika
+- **Odpowiedź**: 
+  - Sukces: Komunikat o powodzeniu
+  - Błąd: Komunikat o błędzie
+
+### PUT /api/user/profile/{userId}/password
+- **Opis**: Aktualizuje hasło użytkownika
+- **Parametry ścieżki**:
+  - `userId`: ID użytkownika do aktualizacji
+- **Treść żądania**: 
+  - `currentPassword`: Aktualne hasło użytkownika
+  - `password`: Nowe hasło użytkownika
+- **Odpowiedź**: 
+  - Sukces: Komunikat o powodzeniu
+  - Błąd: Komunikat o błędzie (np. niepoprawne aktualne hasło)
+
 
 ## Endpointy Tablicy
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@
 
 ### Użytkownicy
 - `GET /api/user/profile/{userId}`: Pobierz profil użytkownika
-- `PUT /api/user/profile/{userId}`: Aktualizuj profil użytkownika
+- `PUT /api/user/profile/{userId}/username`: Aktualizuj nazwę użytkownika
+- `PUT /api/user/profile/{userId}/email`: Aktualizuj email użytkownika
+- `PUT /api/user/profile/{userId}/password`: Aktualizuj hasło użytkownika
 
 ### Tablice
 - `GET /api/boards/user/{userId}`: Pobierz wszystkie tablice dla użytkownika

--- a/src/main/java/com/taskmanager/backend/controllers/UserController.java
+++ b/src/main/java/com/taskmanager/backend/controllers/UserController.java
@@ -1,6 +1,9 @@
 package com.taskmanager.backend.controllers;
 
 import com.taskmanager.backend.models.User;
+import com.taskmanager.backend.payload.request.EmailUpdateRequest;
+import com.taskmanager.backend.payload.request.PasswordUpdateRequest;
+import com.taskmanager.backend.payload.request.UsernameUpdateRequest;
 import com.taskmanager.backend.payload.response.MessageResponse;
 import com.taskmanager.backend.repositories.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,13 +43,13 @@ public class UserController {
     }
 
     /**
-     * Aktualizuj profil uzytkownika
+     * Aktualizuj nazwe uzytkownika
      * @param userId ID uzytkownika do aktualizacji
-     * @param userUpdate zaktualizowane dane uzytkownika
+     * @param usernameRequest nowa nazwa uzytkownika
      * @return komunikat o powodzeniu, jesli aktualizacja sie powiodla
      */
-    @PutMapping("/profile/{userId}")
-    public ResponseEntity<?> updateUserProfile(@PathVariable Long userId, @Valid @RequestBody User userUpdate) {
+    @PutMapping("/profile/{userId}/username")
+    public ResponseEntity<?> updateUsername(@PathVariable Long userId, @Valid @RequestBody UsernameUpdateRequest usernameRequest) {
         Optional<User> userOptional = userRepository.findById(userId);
         if (!userOptional.isPresent()) {
             return ResponseEntity.badRequest().body(new MessageResponse("Blad: Uzytkownik nie znaleziony!"));
@@ -55,28 +58,71 @@ public class UserController {
         User user = userOptional.get();
 
         // Sprawdz czy nazwa uzytkownika jest zmieniana i czy jest juz zajeta
-        if (!user.getUsername().equals(userUpdate.getUsername()) && 
-            userRepository.existsByUsername(userUpdate.getUsername())) {
+        if (!user.getUsername().equals(usernameRequest.getUsername()) && 
+            userRepository.existsByUsername(usernameRequest.getUsername())) {
             return ResponseEntity.badRequest().body(new MessageResponse("Blad: Nazwa uzytkownika jest juz zajeta!"));
         }
 
+        // Aktualizuj nazwe uzytkownika
+        user.setUsername(usernameRequest.getUsername());
+        userRepository.save(user);
+
+        return ResponseEntity.ok(new MessageResponse("Nazwa uzytkownika zaktualizowana pomyslnie!"));
+    }
+
+    /**
+     * Aktualizuj email uzytkownika
+     * @param userId ID uzytkownika do aktualizacji
+     * @param emailRequest nowy email
+     * @return komunikat o powodzeniu, jesli aktualizacja sie powiodla
+     */
+    @PutMapping("/profile/{userId}/email")
+    public ResponseEntity<?> updateEmail(@PathVariable Long userId, @Valid @RequestBody EmailUpdateRequest emailRequest) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        if (!userOptional.isPresent()) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Blad: Uzytkownik nie znaleziony!"));
+        }
+
+        User user = userOptional.get();
+
         // Sprawdz czy email jest zmieniany i czy jest juz w uzyciu
-        if (!user.getEmail().equals(userUpdate.getEmail()) && 
-            userRepository.existsByEmail(userUpdate.getEmail())) {
+        if (!user.getEmail().equals(emailRequest.getEmail()) && 
+            userRepository.existsByEmail(emailRequest.getEmail())) {
             return ResponseEntity.badRequest().body(new MessageResponse("Blad: Email jest juz w uzyciu!"));
         }
 
-        // Aktualizuj pola uzytkownika
-        user.setUsername(userUpdate.getUsername());
-        user.setEmail(userUpdate.getEmail());
-
-        // Aktualizuj haslo jesli podane (bez szyfrowania dla uproszczenia)
-        if (userUpdate.getPassword() != null && !userUpdate.getPassword().isEmpty()) {
-            user.setPassword(userUpdate.getPassword());
-        }
-
+        // Aktualizuj email
+        user.setEmail(emailRequest.getEmail());
         userRepository.save(user);
 
-        return ResponseEntity.ok(new MessageResponse("Profil uzytkownika zaktualizowany pomyslnie!"));
+        return ResponseEntity.ok(new MessageResponse("Email uzytkownika zaktualizowany pomyslnie!"));
     }
+
+    /**
+     * Aktualizuj haslo uzytkownika
+     * @param userId ID uzytkownika do aktualizacji
+     * @param passwordRequest aktualne i nowe haslo
+     * @return komunikat o powodzeniu, jesli aktualizacja sie powiodla
+     */
+    @PutMapping("/profile/{userId}/password")
+    public ResponseEntity<?> updatePassword(@PathVariable Long userId, @Valid @RequestBody PasswordUpdateRequest passwordRequest) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        if (!userOptional.isPresent()) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Blad: Uzytkownik nie znaleziony!"));
+        }
+
+        User user = userOptional.get();
+
+        // Sprawdz czy aktualne haslo jest poprawne
+        if (!user.getPassword().equals(passwordRequest.getCurrentPassword())) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Blad: Aktualne haslo jest niepoprawne!"));
+        }
+
+        // Aktualizuj haslo (bez szyfrowania dla uproszczenia)
+        user.setPassword(passwordRequest.getPassword());
+        userRepository.save(user);
+
+        return ResponseEntity.ok(new MessageResponse("Haslo uzytkownika zaktualizowane pomyslnie!"));
+    }
+
 }

--- a/src/main/java/com/taskmanager/backend/payload/request/EmailUpdateRequest.java
+++ b/src/main/java/com/taskmanager/backend/payload/request/EmailUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.taskmanager.backend.payload.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+
+public class EmailUpdateRequest {
+    @NotBlank
+    @Size(max = 50)
+    @Email
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/taskmanager/backend/payload/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/taskmanager/backend/payload/request/PasswordUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.taskmanager.backend.payload.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+
+public class PasswordUpdateRequest {
+    @NotBlank
+    @Size(max = 120)
+    private String currentPassword;
+
+    @NotBlank
+    @Size(max = 120)
+    private String password;
+
+    public String getCurrentPassword() {
+        return currentPassword;
+    }
+
+    public void setCurrentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/taskmanager/backend/payload/request/UsernameUpdateRequest.java
+++ b/src/main/java/com/taskmanager/backend/payload/request/UsernameUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.taskmanager.backend.payload.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+
+public class UsernameUpdateRequest {
+    @NotBlank
+    @Size(max = 20)
+    private String username;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}


### PR DESCRIPTION
Rozbiłem updateUserProfile na trzy części: username, password i email, a także dodałem wymóg podania aktualnego hasła przed jego zmianą. 